### PR TITLE
Adding Topaz and fixing OPCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,9 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [OPAL](https://github.com/authorizon/opal) - Realtime policy and data updates for your OPA agents on top of websockets pub/sub
 - [OPA Action](https://github.com/koozz/opa-action) - OPA Pull-Request Assessor is a GitHub Action that checks files against policies configured in the same repo
 - [OPA Schema Examples](https://github.com/aavarghese/opa-schema-examples) - Examples of extending the OPA type checker with JSON [schemas](https://www.openpolicyagent.org/docs/latest/schemas/)
-- [OPCR] (https://github.com/opcr-io/policy) - Secure software supply chains for OPA policies. Push, pull, tag, test, version, and sign OPA policies. 
+- [Open Policy Containers](https://github.com/opcr-io/policy) - Secure software supply chains for OPA policies. Push, pull, tag, test, version, and sign OPA policies. 
 - [Snyk IaC Rules](https://github.com/snyk/snyk-iac-rules) - Maintain library of Rego rules, run integration tests and build WASM bundles for distribution of rules. The OPA libraries are used to build WASM bundles.
+- [Topaz](https://github.com/aserto-dev/topaz) - Topaz is an open-source application authorization project that uses OPA as the decision engine and supports Rego policies. 
 - [opactl](https://github.com/onelittlenightmusic/opactl) - A simple tool to turn your Rego rule into CLI command ([blog](https://itnext.io/implement-a-policy-and-use-it-in-cli-de906237c6ab))
 - [alfred](https://github.com/dolevf/Open-Policy-Agent-Alfred) - A self-hosted OPA Playground Alternative
 - [Rönd](https://github.com/rond-authz/rond) - Rönd is a lightweight container that distributes security policy enforcement throughout your application


### PR DESCRIPTION
Updating OPCR to use the full name and adding Topaz to the list of projects that use OPA. Topaz uses OPA as its decision engine and support Rego policies as first-class citizens. Please LMK if you need anything else, thanks so much!