### PR TITLE
feat: add github actions for opa rego testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [gator CLI](https://open-policy-agent.github.io/gatekeeper/website/docs/gator/) - Command line unit test runner for OPA Gatekeeper
 - [ocov](https://github.com/C5T/ocov) - Colors `opa test --coverage` reports in the terminal
 - [opa-codecov](https://github.com/SVilgelm/opa-codecov) - Convert OPA test coverage report to a JSON format supported by Codecov
-- [GitHub Actions for OPA Rego Policy Test](https://github.com/masterpointio/github-action-opa-rego-test) - GitHub Action to automate testing for your OPA Rego policies and generates a report.
+- [github-action-opa-rego-test](https://github.com/masterpointio/github-action-opa-rego-test) - GitHub Action to automate testing for your OPA Rego policies and generates a report.
 
 ### Testing Blogs and Articles
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [gator CLI](https://open-policy-agent.github.io/gatekeeper/website/docs/gator/) - Command line unit test runner for OPA Gatekeeper
 - [ocov](https://github.com/C5T/ocov) - Colors `opa test --coverage` reports in the terminal
 - [opa-codecov](https://github.com/SVilgelm/opa-codecov) - Convert OPA test coverage report to a JSON format supported by Codecov
+- [GitHub Actions for OPA Rego Policy Test](https://github.com/masterpointio/github-action-opa-rego-test) - GitHub Action to automate testing for your OPA Rego policies and generates a report.
 
 ### Testing Blogs and Articles
 


### PR DESCRIPTION
GitHub Actions that automates testing OPA policies on GitHub and also generates a report including coverage and test results!