### PR TITLE
Add opa-wasmtime, a wasm sdk for python versions above 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [JVM](https://github.com/sangkeon/java-opa-wasm) - Java SDK for calling Wasm-compiled policies. Uses wasmtime.
 - [Rust](https://github.com/matrix-org/rust-opa-wasm) - A crate to use OPA policies compiled to Wasm.
 - [regorus](https://github.com/microsoft/regorus/tree/main/bindings/wasm) - Evaluate Rego policies in WASM using Regorus. Try it out at [Regorus Playground](https://anakrish.github.io/regorus-playground/).
+- [opa-wasmtime](https://github.com/nickdeis/python-opa-wasmtime) - An OPA WebAssembly SDK for Python based on wasmtime (for Python versions greater than 3.9)
 
 ### WebAssembly Blogs and Articles
 


### PR DESCRIPTION
Hey all,

I wrote this a while back to see if wasmtime could be used instead of wasmer as WebAssembly runtime for an OPA SDK, since wasmer only supports python 3.10 and below.

Let me know if this isn't important enough to add!