### PR TITLE
Add rego-skill to Tools and Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [Rönd](https://github.com/rond-authz/rond) - Rönd is a lightweight container that distributes security policy enforcement throughout your application
 - [rq (Rego Query)](https://git.sr.ht/~charles/rq) - jq-inspired tool to bring Rego to your shell pipelines
 - [opa-explorer](https://github.com/srenatus/opa-explorer) - Visual tool for exploring the different compilation stages of the OPA topdown compiler
+- [rego-skill](https://github.com/Void3110/rego-skill) - Claude Code skill for AI-assisted Rego policy development with mandatory test workflow, security review checklist, and 114 tests covering RBAC, API Gateway, and ABAC patterns
 - [mcov](https://github.com/styrainc/mcov) - A tool that'll check your Rego source files and report the minimum compatible OPA version required
 - [dependency-management-data (DMD)](https://dmd.tanna.dev) is a set of tooling to get a better understanding of the use of dependencies across your organisation. DMD supports using Open Policy Agent to write more complex rules around dependency usage than can be done using the SQL interface.
 


### PR DESCRIPTION
## What is rego-skill?

A Claude Code skill that provides AI-assisted OPA Rego policy development following security best practices.

## How it relates to OPA

- Generates Rego policies with mandatory `default allow := false`
- Enforces test-driven workflow: every policy gets `*_test.rego`
- Includes security review checklist (authorization bypass, privilege escalation, path traversal)
- Uses modern Rego syntax (`import rego.v1`, `if`, `in`, `every`)
- Provides patterns for RBAC, ABAC, and API Gateway authorization

## What's included

- 6 documentation files (SKILL.md, SECURITY.md, TESTING.md, GENERATE.md, BEST-PRACTICES.md)
- 114 passing tests across examples
- Production-validated against real 8,000+ line Rego codebase (299 additional tests)

## Repository

https://github.com/Void3110/rego-skill

## License

MIT