### PR TITLE
Add protect-mcp to Tools and Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [mcov](https://github.com/styrainc/mcov) - A tool that'll check your Rego source files and report the minimum compatible OPA version required
 - [dependency-management-data (DMD)](https://dmd.tanna.dev) is a set of tooling to get a better understanding of the use of dependencies across your organisation. DMD supports using Open Policy Agent to write more complex rules around dependency usage than can be done using the SQL interface.
 - [RegoLab](https://github.com/HZMonama/regolab) - RegoLab is a web-based playground for writing and testing Open Policy Agent Rego policies with real-time evaluation and data simulation.
+- [protect-mcp](https://github.com/ScopeBlind/scopeblind-gateway) - MCP gateway with Cedar/OPA policy evaluation and Ed25519 signed decision receipts. Every tool call produces a Veritas Acta receipt — independently verifiable, offline, forever.
 
 ## Other Usecases
 


### PR DESCRIPTION
## Summary

Adds [protect-mcp](https://github.com/ScopeBlind/scopeblind-gateway) to the Tools and Utilities section.

protect-mcp is an MCP gateway that wraps AI agent tool calls with per-tool Cedar/OPA policies. Every authorization decision (allow, deny, scope reduction) produces a signed [Veritas Acta](https://veritasacta.com) receipt — Ed25519 + JCS canonicalization, independently verifiable offline.

- npm: [protect-mcp](https://www.npmjs.com/package/protect-mcp) (10K+ monthly downloads)
- Works with Claude Code hooks and as a standalone MCP wrapper
- Cedar WASM policy evaluation on-device
- [IETF Internet-Draft](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) for the receipt format