### PR TITLE
Add Terraform section with awesome-terraform-compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 
 - [Nomad Admission Control Proxy](https://github.com/mxab/nacp) - An admission controller that can be used as a proxy to Nomad's API for mutation and validation with builtin OPA support.
 
+## Terraform
+
+- [awesome-terraform-compliance](https://github.com/antonbabenko/awesome-terraform-compliance) - Curated list of OPA/Rego policy libraries, IaC scanners (Conftest, Regula, Fugue), and compliance resources for Terraform and OpenTofu.
+
 ## Datasource Integrations
 
 - [Kafka Authorizer](https://github.com/StyraInc/opa-kafka-plugin) - Kafka authorizer plugin using OPA, with example policies


### PR DESCRIPTION
Hey @anderseknert, good to be back over here :)

Following up on #79 - since you said it was fine to create a new section, I added `## Terraform` right after `## Nomad` (matching the existing platform section pattern alongside Kubernetes and Nomad). Currently it has one entry: [awesome-terraform-compliance](https://github.com/antonbabenko/awesome-terraform-compliance), which curates OPA/Rego policy libraries, IaC scanners (Conftest, Regula, Fugue), and compliance resources for Terraform/OpenTofu.

The section can grow over time as more OPA-on-Terraform content lands - happy to keep an eye on it and seed entries from the wider Terraform/OpenTofu community.

Thanks!