### PR TITLE
Add agt-policies-nigeria — African fintech & AI agent compliance policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [Confectionary](https://github.com/Cigna/confectionery) - A library of rules for Conftest used to detect Terraform misconfigurations.
 - [Kubescape Rego library](https://github.com/kubescape/regolibrary) - Comprehensive set of Kubernetes policies from Kubescape
 - [Kubernetes Security Policies](https://github.com/raspbernetes/k8s-security-policies) - Raspernetes library for fortifying cluster configurations
+- [agt-policies-nigeria](https://github.com/kingztech2019/agt-policies-nigeria) - Policy-as-Code for African AI agent compliance: NDPA 2023, CBN transaction limits, BVN/NIN data protection, NFIU AML/CFT, and POPIA. Includes 88 OPA tests, CI pipeline, and full compliance mapping.
+
 
 ## Language and Platform Integrations
 


### PR DESCRIPTION
## What this adds

[agt-policies-nigeria](https://github.com/kingztech2019/agt-policies-nigeria) is a 
Policy-as-Code pack for African regulatory compliance targeting AI agents:

- NDPA 2023 (Nigeria Data Protection Act) — cross-border transfer restrictions
- CBN transaction limits — tiered KYC, NIP ₦10M cap, maker-checker enforcement  
- BVN/NIN data protection — NIBSS/NIMC identifier masking
- NFIU AML/CFT — structuring detection, CTR threshold routing
- POPIA (South Africa)

Includes 88 OPA tests, GitHub Actions CI, and a compliance mapping document 
(regulation section → Rego rule → example input → expected decision).

Most OPA examples cover Kubernetes, RBAC, and cloud security. This fills a gap: 
African fintech and AI agent compliance. No other Rego policy library covers 
NDPA, CBN, or BVN/NIN.